### PR TITLE
Fix links to Markdown docs

### DIFF
--- a/index.html
+++ b/index.html
@@ -123,7 +123,7 @@ test('should order elements from the smallest to the highest', () => fc.assert(
 							<li><em>arr => { ... }</em> checks the output against the generated value</li>
 						</ul>
 						<p class="guide-step">
-							<a href="https://github.com/dubzzz/fast-check/blob/master/documentation/HandsOnPropertyBased.md"><button>Full tutorial</button></a>
+							<a href="https://github.com/dubzzz/fast-check/blob/master/documentation/1-Guides/HandsOnPropertyBased.md"><button>Full tutorial</button></a>
 						</p>
 					</div>
 				</div>
@@ -165,7 +165,7 @@ test('should order elements from the smallest to the highest', () => fc.assert(
 							Such property was able to detect bugs in both <em>js-yaml</em> and <em>query-string</em>
 						</p>
 						<p class="guide-step">
-							<a href="https://github.com/dubzzz/fast-check/blob/master/documentation/Arbitraries.md"><button>Discover other built-in types</button></a>
+							<a href="https://github.com/dubzzz/fast-check/blob/master/documentation/1-Guides/Arbitraries.md"><button>Discover other built-in types</button></a>
 						</p>
 					</div>
 				</div>
@@ -203,7 +203,7 @@ Got error: Property failed by returning false</code></pre>
 							If you want to replay the whole test suite, you should only set the <em>seed</em>
 						</p>
 						<p class="guide-step">
-							<a href="https://github.com/dubzzz/fast-check/blob/master/documentation/Tips.md"><button>More tips</button></a>
+							<a href="https://github.com/dubzzz/fast-check/blob/master/documentation/1-Guides/Tips.md"><button>More tips</button></a>
 						</p>
 					</div>
 				</div>
@@ -243,7 +243,7 @@ Encountered failures were:
 - ["","",">q"]
 - ["","",""]</code></pre>
 						<p class="guide-step">
-							<a href="https://github.com/dubzzz/fast-check/blob/master/documentation/Tips.md"><button>More tips</button></a>
+							<a href="https://github.com/dubzzz/fast-check/blob/master/documentation/1-Guides/Tips.md"><button>More tips</button></a>
 						</p>
 					</div>
 				</div>


### PR DESCRIPTION
They were all moved into `documentation/1-Guides/` by dubzzz/fast-check#343