### PR TITLE
Revert "Fix links to Markdown docs (#1)"

### DIFF
--- a/index.html
+++ b/index.html
@@ -123,7 +123,7 @@ test('should order elements from the smallest to the highest', () => fc.assert(
 							<li><em>arr => { ... }</em> checks the output against the generated value</li>
 						</ul>
 						<p class="guide-step">
-							<a href="https://github.com/dubzzz/fast-check/blob/master/documentation/1-Guides/HandsOnPropertyBased.md"><button>Full tutorial</button></a>
+							<a href="https://github.com/dubzzz/fast-check/blob/master/documentation/HandsOnPropertyBased.md"><button>Full tutorial</button></a>
 						</p>
 					</div>
 				</div>
@@ -165,7 +165,7 @@ test('should order elements from the smallest to the highest', () => fc.assert(
 							Such property was able to detect bugs in both <em>js-yaml</em> and <em>query-string</em>
 						</p>
 						<p class="guide-step">
-							<a href="https://github.com/dubzzz/fast-check/blob/master/documentation/1-Guides/Arbitraries.md"><button>Discover other built-in types</button></a>
+							<a href="https://github.com/dubzzz/fast-check/blob/master/documentation/Arbitraries.md"><button>Discover other built-in types</button></a>
 						</p>
 					</div>
 				</div>
@@ -203,7 +203,7 @@ Got error: Property failed by returning false</code></pre>
 							If you want to replay the whole test suite, you should only set the <em>seed</em>
 						</p>
 						<p class="guide-step">
-							<a href="https://github.com/dubzzz/fast-check/blob/master/documentation/1-Guides/Tips.md"><button>More tips</button></a>
+							<a href="https://github.com/dubzzz/fast-check/blob/master/documentation/Tips.md"><button>More tips</button></a>
 						</p>
 					</div>
 				</div>
@@ -243,7 +243,7 @@ Encountered failures were:
 - ["","",">q"]
 - ["","",""]</code></pre>
 						<p class="guide-step">
-							<a href="https://github.com/dubzzz/fast-check/blob/master/documentation/1-Guides/Tips.md"><button>More tips</button></a>
+							<a href="https://github.com/dubzzz/fast-check/blob/master/documentation/Tips.md"><button>More tips</button></a>
 						</p>
 					</div>
 				</div>


### PR DESCRIPTION
looks like the situation in #1 is no longer the case? these links appear to be broken now (seemingly via this PR: https://github.com/dubzzz/fast-check/pull/936/).

This reverts commit e0bd4a64846e1e8302dd649e584573277a149d7c.